### PR TITLE
Fix incorrect agent version in Android instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ yarn add @bibabovn/react-native-newrelic
       }
       dependencies {
         ...
-        classpath "com.newrelic.agent.android:agent-gradle-plugin:5.+"
+        classpath "com.newrelic.agent.android:agent-gradle-plugin:6.+"
       }
     }
   ```
@@ -54,7 +54,7 @@ yarn add @bibabovn/react-native-newrelic
     ...
     dependencies {
       ...
-      implementation "com.newrelic.agent.android:android-agent:5.+"
+      implementation "com.newrelic.agent.android:android-agent:6.+"
     }
   ```
 - Update the app's `MainApplication.java` file (./android/app/src/main/java/'{package}/MainApplication.java')


### PR DESCRIPTION
Android instruction mention that newrelic 5.+ is used for Android. However this should be `6.+` as also defined in `android/gradle.properties`
https://github.com/huynq1175/react-native-newrelic-agent/blob/master/android/gradle.properties#L5