### PR TITLE
Fix recordHandledException on iOS

### DIFF
--- a/ios/NewrelicAgent.m
+++ b/ios/NewrelicAgent.m
@@ -224,8 +224,7 @@ RCT_EXPORT_METHOD(recordHandledException:(NSDictionary *)jsError attributes:(NSD
 {
     @try {
         NSError* e = [self pareJSErrorToNSException:jsError];
-
-        [NewRelic recordHandledException:(NSException * _Nonnull)e withAttributes:(NSDictionary * _Nullable)attributes];
+        [NewRelic recordError:e attributes:attributes];
         resolve(@true);
     } @catch (NSException *exception) {
         [NewRelic recordHandledException:exception];


### PR DESCRIPTION
Reverts recordHandledException, because casting `NSError` to `NSException` is invalid and produces an `unrecognized selector` issue exception.

Also removes the type casting as this masked the bug because of the explicit type-casting.